### PR TITLE
Pass error details

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function(opts){
     try {
       this.push(toToml(file));
     } catch(error) {
-      this.emit('error', new gutil.PluginError('gulp-toml', error.message));
+      this.emit('error', new gutil.PluginError('gulp-toml', error.message, {'error': error}));
     }
     return cb();
   });

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "url": "https://github.com/will-ob/gulp-toml/issues"
   },
   "dependencies": {
-    "gulp-util": "~2.2.14",
+    "gulp-util": "~3.0.8",
     "toml": "~2.3.0",
     "through2": "~0.4.1"
   },
   "devDependencies": {
     "mocha": "~1.18.2",
     "assert": "~1.1.1",
-    "gulp-util": "~2.2.14"
+    "gulp-util": "~3.0.8"
   }
 }


### PR DESCRIPTION
Hi, this PR adds things like the line and column number of parse errors.

I've bumped `gulp-util` because its only in later versions that it copies an error's metadata

Old error:
```
[11:02:17] Error in plugin 'gulp-toml'
Expected "#", "\n", "\r" or [ \t] but "s" found.
```

New error:
```
[11:00:07] SyntaxError in plugin 'gulp-toml'
Message:
    Expected "#", "\n", "\r" or [ \t] but "s" found.
Details:
    expected: [object Object],[object Object],[object Object],[object Object]
    found: s
    offset: 3915
    line: 117
    column: 24
```

